### PR TITLE
Add escapse function raw text

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,0 +1,32 @@
+import asynctest
+from aiohttp.web_request import Request
+from asynctest import mock
+
+from aiohttp_ultrajson import get_json
+
+
+class TestViews(asynctest.TestCase):
+
+    async def test_get_json(self) -> None:
+        cases = [
+            (
+                '{"data": "（）"}',
+                {'data': '()'}
+            ),
+            (
+                '{"data": "※＂＂　"}',
+                {'data': '※\\\"\\\" '}
+            ),
+            (
+                '{"data": "＼"}',
+                {'data': '\\\\'}
+            )
+        ]
+
+        for raw_text, expected_text in cases:
+            mock_request: Request = mock.Mock(spec=Request)
+            mock_request.text = asynctest.CoroutineMock(return_value=raw_text)
+
+            result = await get_json(mock_request)
+
+            self.assertEqual(result, expected_text)


### PR DESCRIPTION
from: #1 

## Problem
- Because there were no escape function, It crash JSON format after normalizing raw text, like `＂`, `＼`.
- They will become half width double quote(`"`), half width back slash(`\`), and crash JSON format

## What I changed
- Add escape function
- Add test code